### PR TITLE
feat: version bump to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nilrag"
-version = "0.1.1"
+version = "0.1.2"
 description = "nilRAG SDK"
 authors = [
     { name = "Manuel Santos", email = "manuel.santos@nillion.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -403,7 +403,7 @@ wheels = [
 
 [[package]]
 name = "nilrag"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "ecdsa" },


### PR DESCRIPTION
This PR bumps the version to 0.1.2 to permit the release that downgrades numpy to 1.26.4