### PR TITLE
feat: update to latest nilql and nilai models

### DIFF
--- a/examples/client_query.py
+++ b/examples/client_query.py
@@ -39,7 +39,7 @@ print('Query nilAI with nilRAG...')
 response = nilDB.nilai_chat_completion(
     nilai_url="NILAI_URL", # Update with your nilAI node url
     token="NILAI_TOKEN", # Update with your nilAI token
-    model="meta-llama/Llama-3.1-8B-Instruct",
+    model="meta-llama/Llama-3.2-3B-Instruct",
     messages=[
         {"role": "user", "content": "Tell me about Asia."}
     ],

--- a/examples/client_query.py
+++ b/examples/client_query.py
@@ -37,8 +37,9 @@ print()
 
 print('Query nilAI with nilRAG...')
 response = nilDB.nilai_chat_completion(
-    nilai_url="http://127.0.0.1:8080/",
-    token="1770c101-dd83-4fbc-b996-ef8121889172",
+    nilai_url="NILAI_URL", # Update with your nilAI node url
+    token="NILAI_TOKEN", # Update with your nilAI token
+    model="meta-llama/Llama-3.1-8B-Instruct",
     messages=[
         {"role": "user", "content": "Tell me about Asia."}
     ],

--- a/examples/data_owner_upload.py
+++ b/examples/data_owner_upload.py
@@ -16,8 +16,7 @@ from nilrag.nildb_requests import NilDB, Node
 
 
 JSON_FILE = "examples/nildb_config.json"
-# Update with your secret key
-SECRET_KEY = "XXXXXXXXXXXXXXXXXXXXXXXX"
+SECRET_KEY = "YOUR_SECRET_KEY" # Update with your SecretVault (nilDB) Secret Key
 FILE_PATH = 'examples/data/cities.txt'
 
 # Load NilDB from JSON file if it exists
@@ -41,15 +40,15 @@ else:
     print("Error: NilDB configuration file not found.")
     sys.exit(1)
 
-nilDB.generate_jwt(SECRET_KEY, ttl=100000000)
+nilDB.generate_jwt(SECRET_KEY, ttl=3600)
 
 print("NilDB instance:", nilDB)
 print()
 
 # Initialize secret keys for different modes of operation
 num_nodes = len(nilDB.nodes)
-additive_key = nilql.secret_key({'nodes': [{}] * num_nodes}, {'sum': True})
-xor_key = nilql.secret_key({'nodes': [{}] * num_nodes}, {'store': True})
+additive_key = nilql.ClusterKey.generate({'nodes': [{}] * num_nodes}, {'sum': True})
+xor_key = nilql.ClusterKey.generate({'nodes': [{}] * num_nodes}, {'store': True})
 
 # Load and process input file
 paragraphs = load_file(FILE_PATH)

--- a/examples/query_nildb_config.json
+++ b/examples/query_nildb_config.json
@@ -2,19 +2,19 @@
     "nodes": [
         {
             "url": "https://nildb-nx8v.nillion.network/api/v1",
-            "bearer_token": "XXXXXXXXXXXXXXXX",
+            "bearer_token": "YOUR_JWT_TOKEN",
             "schema_id": "6aa651af-7762-4aaa-9089-82f8eab16201",
             "diff_query_id": "dfcee886-231d-4a9d-9bdd-857f74a72964"
         },
         {
             "url": "https://nildb-p3mx.nillion.network/api/v1",
-            "bearer_token": "XXXXXXXXXXXXXXXX",
+            "bearer_token": "YOUR_JWT_TOKEN",
             "schema_id": "6aa651af-7762-4aaa-9089-82f8eab16201",
             "diff_query_id": "dfcee886-231d-4a9d-9bdd-857f74a72964"
         },
         {
             "url": "https://nildb-rugk.nillion.network/api/v1",
-            "bearer_token": "XXXXXXXXXXXXXXXX",
+            "bearer_token": "YOUR_JWT_TOKEN",
             "schema_id": "6aa651af-7762-4aaa-9089-82f8eab16201",
             "diff_query_id": "dfcee886-231d-4a9d-9bdd-857f74a72964"
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "ecdsa>=0.19.0",
-    "nilql==0.0.0a3",
+    "cryptography~=3.4",
+    "nilql==0.0.0a12",
     "numpy<2.0.0",
     "pyjwt>=2.10.1",
     "sentence-transformers>=3.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nilrag"
-version = "0.1.2"
+version = "0.1.3"
 description = "nilRAG SDK"
 authors = [
     { name = "Manuel Santos", email = "manuel.santos@nillion.com" },

--- a/src/nilrag/nildb_requests.py
+++ b/src/nilrag/nildb_requests.py
@@ -552,7 +552,7 @@ class NilDB:
         nilai_url: str,
         token: str,
         messages: list[dict],
-        model: str = "Llama-3.2-1B-Instruct",
+        model: str = "meta-llama/Llama-3.2-3B-Instruct",
         temperature: float = 0.7,
         max_tokens: int = 2048,
         stream: bool = False,
@@ -564,7 +564,7 @@ class NilDB:
             nilai_url (str): Base URL for the nilai API
             token (str): Bearer token for authentication
             messages (list[dict]): List of message dictionaries (role and content)
-            model (str): AI model to use for completion (default: "Llama-3.2-1B-Instruct")
+            model (str): AI model to use for completion (default: "meta-llama/Llama-3.2-3B-Instruct")
             temperature (float): Sampling temperature (default: 0.7)
             max_tokens (int): Maximum tokens to generate (default: 2048)
             stream (bool): Whether to stream the response (default: False)


### PR DESCRIPTION
Since the package is still anchored to a very old version of nilQL, and using an inference model not currently available on either of the nilAI instances, it's probably best to update those at this point.