### PR TITLE
chore: make response status check backwards compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nilrag"
-version = "0.1.6"
+version = "0.1.7"
 description = "nilRAG SDK"
 authors = [
     { name = "Manuel Santos", email = "manuel.santos@nillion.com" },

--- a/src/nilrag/nildb_requests.py
+++ b/src/nilrag/nildb_requests.py
@@ -171,7 +171,7 @@ class NilDB:
                         async with session.post(
                             url, headers=headers, json=payload, timeout=TIMEOUT
                         ) as response:
-                            if response.status != HTTPStatus.CREATED:
+                            if response.status not in [HTTPStatus.CREATED, HTTPStatus.OK]:
                                 error_text = await response.text()
                                 raise ValueError(
                                     f"Error in POST request: {response.status}, {error_text}"
@@ -255,7 +255,7 @@ class NilDB:
                         async with session.post(
                             url, headers=headers, json=payload, timeout=TIMEOUT
                         ) as response:
-                            if response.status != HTTPStatus.CREATED:
+                            if response.status not in [HTTPStatus.CREATED, HTTPStatus.OK]:
                                 error_text = await response.text()
                                 raise ValueError(
                                     f"Error in POST request: {response.status}, {error_text}"

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "nilrag"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Some nilDB nodes are still deployed on versions with the old status code responses for the schema/query create endpoint.