### PR TITLE
Init store cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ uv run examples/3.client_query.py
 uv run examples/3.client_query.py --config /path/to/config.json --prompt "Your custom query here"
 ```
 
+## Running Benchmarks on RAG using nilDB nodes
+After having nilDB initialized, documents uploaded, the
+client run benchmarks to measure the time it takes to perform RAG using nilDB nodes.
+The response is the most relevant data chunks for a given query.
+
+```shell
+# Use default config and prompt
+uv run benchmarks/nilrag_nildb_nodes.py
+
+# Or specify custom config and prompt
+uv run benchmarks/nilrag_nildb_nodes.py --config /path/to/config.json --prompt "Your custom query here"
+```
 
 ## Running Tests
 ```shell

--- a/benchmarks/nilrag_nildb_nodes.py
+++ b/benchmarks/nilrag_nildb_nodes.py
@@ -1,5 +1,5 @@
 """
-Example of server performing RAG with nilDB nodes.
+Benchmarks of server performing RAG with nilDB nodes.
 """
 
 import argparse
@@ -12,6 +12,7 @@ from nilrag.nildb_requests import ChatCompletionConfig
 
 DEFAULT_CONFIG = "examples/nildb_config.json"
 DEFAULT_PROMPT = "Who is Michelle Ross?"
+ENABLE_BENCHMARKS = True
 
 
 async def main():
@@ -52,7 +53,7 @@ async def main():
 
     print("Perform nilRAG...")
     start_time = time.time()
-    top_chunks = await nil_db.top_num_chunks_execute(args.prompt, 2)
+    top_chunks = await nil_db.top_num_chunks_execute(args.prompt, 2, ENABLE_BENCHMARKS)
     end_time = time.time()
     print(json.dumps(top_chunks, indent=4))
     print(f"Query took {end_time - start_time:.2f} seconds")

--- a/examples/1.init_schema_query.py
+++ b/examples/1.init_schema_query.py
@@ -19,9 +19,12 @@ async def main():
     This script:
     1. Loads the nilDB configuration from a JSON file
     2. Generates JWT tokens for authentication
-    3. Creates a schema for storing embeddings and chunks
-    4. Creates a query for computing differences between embeddings
-    5. Updates the configuration file with the generated IDs and tokens
+    3. Creates a schema for storing cluster centroids, embeddings and chunks
+    4. Creates a schema for storing cluster centroids
+    5. Creates a query for computing differences between embeddings
+    6. Creates a query for computing differences between embeddings with
+       filtered by a cluster centroid
+    7. Updates the configuration file with the generated IDs and tokens
     """
     parser = argparse.ArgumentParser(
         description="Initialize schema and query for nilDB"

--- a/examples/1.init_schema_query.py
+++ b/examples/1.init_schema_query.py
@@ -19,11 +19,11 @@ async def main():
     This script:
     1. Loads the nilDB configuration from a JSON file
     2. Generates JWT tokens for authentication
-    3. Creates a schema for storing cluster centroids, embeddings and chunks
-    4. Creates a schema for storing cluster centroids
+    3. Creates a schema for entries, each with chunk, embedding and cluster centroid it belongs to
+    4. Creates a schema for cluster centroids
     5. Creates a query for computing differences between embeddings
-    6. Creates a query for computing differences between embeddings with
-       filtered by a cluster centroid
+    6. Creates a query for computing differences between embeddings
+       filtered by a cluster's centroid
     7. Updates the configuration file with the generated IDs and tokens
     """
     parser = argparse.ArgumentParser(

--- a/examples/1.init_schema_query.py
+++ b/examples/1.init_schema_query.py
@@ -47,6 +47,12 @@ async def main():
     end_time = time.time()
     print(f"Schema initialized successfully in {end_time - start_time:.2f} seconds")
 
+    print("Initializing clusters' schema...")
+    start_time = time.time()
+    clusters_schema_id = await nil_db.init_clusters_schema()
+    end_time = time.time()
+    print(f"Clusters' schema initialized successfully in {end_time - start_time:.2f} seconds")
+
     print("Initializing query...")
     start_time = time.time()
     diff_query_id = await nil_db.init_diff_query()
@@ -59,6 +65,7 @@ async def main():
     for node_data, jwt in zip(data["nodes"], jwts):
         node_data["schema_id"] = schema_id
         node_data["diff_query_id"] = diff_query_id
+        node_data["clusters_schema_id"] = clusters_schema_id
         node_data["bearer_token"] = jwt
     with open(args.config, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)

--- a/examples/1.init_schema_query.py
+++ b/examples/1.init_schema_query.py
@@ -54,7 +54,9 @@ async def main():
     start_time = time.time()
     clusters_schema_id = await nil_db.init_clusters_schema()
     end_time = time.time()
-    print(f"Clusters' schema initialized successfully in {end_time - start_time:.2f} seconds")
+    print(
+        f"Clusters' schema initialized successfully in {end_time - start_time:.2f} seconds"
+    )
 
     print("Initializing query...")
     start_time = time.time()
@@ -66,7 +68,9 @@ async def main():
     start_time = time.time()
     cluster_diff_query_id = await nil_db.init_cluster_diff_query()
     end_time = time.time()
-    print(f"Cluster query initialized successfully in {end_time - start_time:.2f} seconds")
+    print(
+        f"Cluster query initialized successfully in {end_time - start_time:.2f} seconds"
+    )
 
     # Update config file with new IDs and tokens
     with open(args.config, "r", encoding="utf-8") as f:

--- a/examples/1.init_schema_query.py
+++ b/examples/1.init_schema_query.py
@@ -59,6 +59,12 @@ async def main():
     end_time = time.time()
     print(f"Query initialized successfully in {end_time - start_time:.2f} seconds")
 
+    print("Initializing query for clustered data...")
+    start_time = time.time()
+    cluster_diff_query_id = await nil_db.init_cluster_diff_query()
+    end_time = time.time()
+    print(f"Cluster query initialized successfully in {end_time - start_time:.2f} seconds")
+
     # Update config file with new IDs and tokens
     with open(args.config, "r", encoding="utf-8") as f:
         data = json.load(f)
@@ -66,6 +72,7 @@ async def main():
         node_data["schema_id"] = schema_id
         node_data["diff_query_id"] = diff_query_id
         node_data["clusters_schema_id"] = clusters_schema_id
+        node_data["cluster_diff_query_id"] = cluster_diff_query_id
         node_data["bearer_token"] = jwt
     with open(args.config, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -44,7 +44,7 @@ async def main():
     parser.add_argument(
         "--clusters",
         type=int,
-        default=1,
+        default=DEFAULT_NUMBER_CLUSTERS,
         help="Number of clusters to use (default: {DEFAULT_NUMBER_CLUSTERS})",
     )
     args = parser.parse_args()

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -43,10 +43,10 @@ async def main():
         help=f"Path to data file to upload (default: {DEFAULT_FILE_PATH})",
     )
     parser.add_argument(
-    "--clusters",
-    type=int,
-    default=1,
-    help="Number of clusters to use (default: {DEFAULT_NUMBER_CLUSTERS})"
+        "--clusters",
+        type=int,
+        default=1,
+        help="Number of clusters to use (default: {DEFAULT_NUMBER_CLUSTERS})"
     )
     args = parser.parse_args()
 

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -90,12 +90,25 @@ async def main():
     if args.clusters > 1:
         # Clustering embeddings
         start_time = time.time()
-        labels, centroids = cluster_embeddings(embeddings,args.clusters)
+        labels, centroids = cluster_embeddings(embeddings, args.clusters)
         end_time = time.time()
         print(f"Data clustered in {end_time - start_time:.2f} seconds")
+        # Save the chunks grouped by cluster into a .txt file
+        output_path = "clustered_chunks.txt"
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write("=== Cluster Sizes ===\n")
+            for i in range(args.clusters):
+                size = sum(label == i for label in labels)
+                f.write(f"Cluster {i}: {size} chunks\n")
+            for i in range(args.clusters):
+                f.write(f"\n--- Cluster {i} ---\n")
+                for idx, label in enumerate(labels):
+                    if label == i:
+                        f.write(f"[{idx}] {chunks[idx]}\n")
+        print(f"Chunks grouped by cluster saved to {output_path}")
         print("Uploading data with clustering labels...")
         start_time = time.time()
-        await nil_db.upload_data(embeddings_shares, chunks_shares, labels, centroids)
+        await nil_db.upload_data(embeddings_shares, chunks_shares, labels = labels, centroids = centroids)
         end_time = time.time()
         print(f"Data uploaded in {end_time - start_time:.2f} seconds")
     else :

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -9,9 +9,8 @@ import time
 import nilql
 
 from nilrag.config import load_nil_db_config
-from nilrag.util import (create_chunks, encrypt_float_list,
-                         generate_embeddings_huggingface, load_file,
-                         cluster_embeddings)
+from nilrag.util import (cluster_embeddings, create_chunks, encrypt_float_list,
+                         generate_embeddings_huggingface, load_file)
 
 DEFAULT_CONFIG = "examples/nildb_config.json"
 DEFAULT_FILE_PATH = "examples/data/20-fake.txt"
@@ -46,7 +45,7 @@ async def main():
         "--clusters",
         type=int,
         default=1,
-        help="Number of clusters to use (default: {DEFAULT_NUMBER_CLUSTERS})"
+        help="Number of clusters to use (default: {DEFAULT_NUMBER_CLUSTERS})",
     )
     args = parser.parse_args()
 
@@ -96,10 +95,12 @@ async def main():
         print(f"Data clustered in {end_time - start_time:.2f} seconds")
         print("Uploading data with clustering labels...")
         start_time = time.time()
-        await nil_db.upload_data(embeddings_shares, chunks_shares, labels = labels, centroids = centroids)
+        await nil_db.upload_data(
+            embeddings_shares, chunks_shares, labels=labels, centroids=centroids
+        )
         end_time = time.time()
         print(f"Data uploaded in {end_time - start_time:.2f} seconds")
-    else :
+    else:
         print("Uploading data...")
         start_time = time.time()
         await nil_db.upload_data(embeddings_shares, chunks_shares)

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -55,6 +55,7 @@ async def main():
         args.config,
         require_bearer_token=True,
         require_schema_id=True,
+        require_clusters_schema_id=True,
     )
     print(nil_db)
     print()

--- a/examples/2.data_owner_upload.py
+++ b/examples/2.data_owner_upload.py
@@ -89,23 +89,11 @@ async def main():
     # Upload encrypted data to nilDB
     if args.clusters > 1:
         # Clustering embeddings
+        print(f"Clustering the data in {args.clusters} clusters...")
         start_time = time.time()
         labels, centroids = cluster_embeddings(embeddings, args.clusters)
         end_time = time.time()
         print(f"Data clustered in {end_time - start_time:.2f} seconds")
-        # Save the chunks grouped by cluster into a .txt file
-        output_path = "clustered_chunks.txt"
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write("=== Cluster Sizes ===\n")
-            for i in range(args.clusters):
-                size = sum(label == i for label in labels)
-                f.write(f"Cluster {i}: {size} chunks\n")
-            for i in range(args.clusters):
-                f.write(f"\n--- Cluster {i} ---\n")
-                for idx, label in enumerate(labels):
-                    if label == i:
-                        f.write(f"[{idx}] {chunks[idx]}\n")
-        print(f"Chunks grouped by cluster saved to {output_path}")
         print("Uploading data with clustering labels...")
         start_time = time.time()
         await nil_db.upload_data(embeddings_shares, chunks_shares, labels = labels, centroids = centroids)

--- a/examples/3.client_query.py
+++ b/examples/3.client_query.py
@@ -38,12 +38,6 @@ async def main():
         default=DEFAULT_PROMPT,
         help=f"Query prompt (default: {DEFAULT_PROMPT})",
     )
-    parser.add_argument(
-        "--fake_queries",
-        type=str,
-        default=DEFAULT_PROMPT,
-        help=f"Number of fake queries to produce (default: {DEFAULT_FAKE_QUERIES})",
-    )
     args = parser.parse_args()
 
     # Load NilDB configuration
@@ -53,39 +47,10 @@ async def main():
         require_schema_id=True,
         require_diff_query_id=True,
         require_clusters_schema_id=True,
+        require_cluster_diff_query_id=True,
     )
     print(nil_db)
     print()
-
-    # Check if clustering was performed
-    print("Starting cluster check...")
-    start_time = time.time()
-    num_clusters = await nil_db.check_clustering()
-    cluster_check_time = time.time() - start_time
-    print(f"Cluster check result: {num_clusters} clusters found")
-    print(f"Cluster check took {cluster_check_time:.2f} seconds")
-    
-    filter = {}
-    closest_centroid = None  # NEW: Variable to store the closest centroid
-    if num_clusters > 1:
-        print(f"Clustering was performed - found {num_clusters} clusters")
-        # Find closest centroid using the prompt
-        print(f"Finding closest centroid for prompt: {args.prompt}")
-        start_time = time.time()
-        closest_centroid_idx, closest_centroid, centroid_id = await nil_db.get_closest_centroid_index(args.prompt)
-        centroid_time = time.time() - start_time
-        print(f"Finding closest centroid took {centroid_time:.2f} seconds")
-        
-        if closest_centroid_idx is not None:
-            print(f"Closest centroid found:")
-            print(f"Index: {closest_centroid_idx}")
-            print(f"ID: {centroid_id}")
-            print(f"Centroid vector (first 5 values): {closest_centroid[:5]}")
-            filter = {
-                "cluster_centroid": closest_centroid
-            }
-    else:
-        print("No clustering was performed - no centroids found in clusters schema")
 
     print("Query nilAI with nilRAG...")
     start_time = time.time()
@@ -97,18 +62,11 @@ async def main():
         temperature=0.2,
         max_tokens=2048,
         stream=False,
-        filter=filter,
     )
-    #Pass closest_centroid to diff_query_execute
-    response = nil_db.nilai_chat_completion(config, closest_centroid=closest_centroid)
-    query_time = time.time() - start_time
+    response = nil_db.nilai_chat_completion(config)
+    end_time = time.time()
     print(json.dumps(response, indent=4))
-    print(f"Timing summary:")
-    if num_clusters > 1:
-        print(f"Cluster check: {cluster_check_time:.2f} seconds")
-        print(f"Finding closest centroid: {centroid_time:.2f} seconds")
-    print(f"Query execution: {query_time:.2f} seconds")
-    print(f"Total time: {cluster_check_time + (centroid_time if num_clusters > 1 else 0) + query_time:.2f} seconds")
+    print(f"Query took {end_time - start_time:.2f} seconds")
 
 
 if __name__ == "__main__":

--- a/examples/3.client_query.py
+++ b/examples/3.client_query.py
@@ -12,6 +12,7 @@ from nilrag.nildb_requests import ChatCompletionConfig
 
 DEFAULT_CONFIG = "examples/nildb_config.json"
 DEFAULT_PROMPT = "Who is Danielle Miller?"
+DEFAULT_FAKE_QUERIES = 0
 
 
 async def main():
@@ -37,6 +38,12 @@ async def main():
         default=DEFAULT_PROMPT,
         help=f"Query prompt (default: {DEFAULT_PROMPT})",
     )
+    parser.add_argument(
+        "--fake_queries",
+        type=str,
+        default=DEFAULT_PROMPT,
+        help=f"Number of fake queries to produce (default: {DEFAULT_FAKE_QUERIES})",
+    )
     args = parser.parse_args()
 
     # Load NilDB configuration
@@ -45,9 +52,40 @@ async def main():
         require_bearer_token=True,
         require_schema_id=True,
         require_diff_query_id=True,
+        require_clusters_schema_id=True,
     )
     print(nil_db)
     print()
+
+    # Check if clustering was performed
+    print("Starting cluster check...")
+    start_time = time.time()
+    num_clusters = await nil_db.check_clustering()
+    cluster_check_time = time.time() - start_time
+    print(f"Cluster check result: {num_clusters} clusters found")
+    print(f"Cluster check took {cluster_check_time:.2f} seconds")
+    
+    filter = {}
+    closest_centroid = None  # NEW: Variable to store the closest centroid
+    if num_clusters > 1:
+        print(f"Clustering was performed - found {num_clusters} clusters")
+        # Find closest centroid using the prompt
+        print(f"Finding closest centroid for prompt: {args.prompt}")
+        start_time = time.time()
+        closest_centroid_idx, closest_centroid, centroid_id = await nil_db.get_closest_centroid_index(args.prompt)
+        centroid_time = time.time() - start_time
+        print(f"Finding closest centroid took {centroid_time:.2f} seconds")
+        
+        if closest_centroid_idx is not None:
+            print(f"Closest centroid found:")
+            print(f"Index: {closest_centroid_idx}")
+            print(f"ID: {centroid_id}")
+            print(f"Centroid vector (first 5 values): {closest_centroid[:5]}")
+            filter = {
+                "cluster_centroid": closest_centroid
+            }
+    else:
+        print("No clustering was performed - no centroids found in clusters schema")
 
     print("Query nilAI with nilRAG...")
     start_time = time.time()
@@ -59,11 +97,18 @@ async def main():
         temperature=0.2,
         max_tokens=2048,
         stream=False,
+        filter=filter,
     )
-    response = nil_db.nilai_chat_completion(config)
-    end_time = time.time()
+    #Pass closest_centroid to diff_query_execute
+    response = nil_db.nilai_chat_completion(config, closest_centroid=closest_centroid)
+    query_time = time.time() - start_time
     print(json.dumps(response, indent=4))
-    print(f"Query took {end_time - start_time:.2f} seconds")
+    print(f"Timing summary:")
+    if num_clusters > 1:
+        print(f"Cluster check: {cluster_check_time:.2f} seconds")
+        print(f"Finding closest centroid: {centroid_time:.2f} seconds")
+    print(f"Query execution: {query_time:.2f} seconds")
+    print(f"Total time: {cluster_check_time + (centroid_time if num_clusters > 1 else 0) + query_time:.2f} seconds")
 
 
 if __name__ == "__main__":

--- a/examples/3.client_query.py
+++ b/examples/3.client_query.py
@@ -11,7 +11,7 @@ from nilrag.config import load_nil_db_config
 from nilrag.nildb_requests import ChatCompletionConfig
 
 DEFAULT_CONFIG = "examples/nildb_config.json"
-DEFAULT_PROMPT = "Who is Danielle Miller?"
+DEFAULT_PROMPT = "Who is Michelle Ross?"
 DEFAULT_FAKE_QUERIES = 0
 
 

--- a/examples/4.server_nilrag.py
+++ b/examples/4.server_nilrag.py
@@ -1,0 +1,62 @@
+"""
+Example of server performing RAG with nilDB nodes.
+"""
+
+import argparse
+import asyncio
+import json
+import time
+
+from nilrag.config import load_nil_db_config
+from nilrag.nildb_requests import ChatCompletionConfig
+
+DEFAULT_CONFIG = "examples/nildb_config.json"
+DEFAULT_PROMPT = "Who is Danielle Miller?"
+
+
+async def main():
+    """
+    Performing RAG using nilDB nodes. This is the RAG logic to be run on nilAI.
+
+    This script:
+    1. Loads the nilDB configuration
+    2. Performs RAG using nilDB nodes
+    3. Displays the response and timing information
+    """
+    parser = argparse.ArgumentParser(description="Query nilDB using nilRAG")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=DEFAULT_CONFIG,
+        help=f"Path to nilDB config file (default: {DEFAULT_CONFIG})",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=DEFAULT_PROMPT,
+        help=f"Query prompt (default: {DEFAULT_PROMPT})",
+    )
+    args = parser.parse_args()
+
+    # Load NilDB configuration
+    nil_db, _ = load_nil_db_config(
+        args.config,
+        require_bearer_token=True,
+        require_schema_id=True,
+        require_diff_query_id=True,
+        require_clusters_schema_id=True,
+        require_cluster_diff_query_id=True,
+    )
+    print(nil_db)
+    print()
+
+    print("Perform nilRAG...")
+    start_time = time.time()
+    top_chunks = await nil_db.top_num_chunks_execute(args.prompt, 2)
+    end_time = time.time()
+    print(json.dumps(top_chunks, indent=4))
+    print(f"Query took {end_time - start_time:.2f} seconds")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/4.server_nilrag.py
+++ b/examples/4.server_nilrag.py
@@ -11,7 +11,7 @@ from nilrag.config import load_nil_db_config
 from nilrag.nildb_requests import ChatCompletionConfig
 
 DEFAULT_CONFIG = "examples/nildb_config.json"
-DEFAULT_PROMPT = "Who is Danielle Miller?"
+DEFAULT_PROMPT = "Who is Michelle Ross?"
 
 
 async def main():

--- a/examples/data/20-fake.txt
+++ b/examples/data/20-fake.txt
@@ -14,7 +14,7 @@ Mark Guzman works at Swanson, Gonzalez and Kim as a Further education lecturer. 
 
 Kyle Moore works at Jackson, Gray and Lewis as a Economist. Kyle Moore was born on 1915-09-27 and lives at 6206 Caroline Point, Bishopland, MI 34522.
 
-Charles Anderson works at Evans, Parker and Ramirez as a Surveyor, insurance. Charles Anderson was born on 2016-12-13 and lives at 0527 William Walk Suite 976, Lake Jason, MS 97840.
+Michelle Ross works at Davis-Alvarez as a Tree surgeon. Michelle Ross was born on 1946-09-15 and lives at 33554 Deanna Summit Apt. 813, Hurstshire, IA 55587.
 
 Danielle Miller works at Bailey and Sons as a Engineer, mining. Danielle Miller was born on 2007-10-22 and lives at 61586 Michael Greens, New Holly, CO 29872.
 

--- a/examples/nildb_config.sample.json
+++ b/examples/nildb_config.sample.json
@@ -6,7 +6,8 @@
             "bearer_token": "",
             "schema_id": "",
             "diff_query_id": "",
-            "clusters_schema_id": ""
+            "clusters_schema_id": "",
+            "cluster_diff_query_id": ""
         },
         {
             "url": "https://nildb-p3mx.nillion.network/api/v1",
@@ -14,7 +15,9 @@
             "bearer_token": "",
             "schema_id": "",
             "diff_query_id": "",
-            "clusters_schema_id": ""
+            "clusters_schema_id": "",
+            "cluster_diff_query_id": ""
+
         },
         {
             "url": "https://nildb-rugk.nillion.network/api/v1",
@@ -22,7 +25,9 @@
             "bearer_token": "",
             "schema_id": "",
             "diff_query_id": "",
-            "clusters_schema_id": ""
+            "clusters_schema_id": "",
+            "cluster_diff_query_id": ""
+
         }
     ],
     "org_secret_key": "Add you SECRET_KEY here",

--- a/examples/nildb_config.sample.json
+++ b/examples/nildb_config.sample.json
@@ -5,21 +5,24 @@
             "node_id": "did:nil:testnet:nillion1qfrl8nje3nvwh6cryj63mz2y6gsdptvn07nx8v",
             "bearer_token": "",
             "schema_id": "",
-            "diff_query_id": ""
+            "diff_query_id": "",
+            "clusters_schema_id": ""
         },
         {
             "url": "https://nildb-p3mx.nillion.network/api/v1",
             "node_id": "did:nil:testnet:nillion1uak7fgsp69kzfhdd6lfqv69fnzh3lprg2mp3mx",
             "bearer_token": "",
             "schema_id": "",
-            "diff_query_id": ""
+            "diff_query_id": "",
+            "clusters_schema_id": ""
         },
         {
             "url": "https://nildb-rugk.nillion.network/api/v1",
             "node_id": "did:nil:testnet:nillion1kfremrp2mryxrynx66etjl8s7wazxc3rssrugk",
             "bearer_token": "",
             "schema_id": "",
-            "diff_query_id": ""
+            "diff_query_id": "",
+            "clusters_schema_id": ""
         }
     ],
     "org_secret_key": "Add you SECRET_KEY here",

--- a/src/nilrag/config.py
+++ b/src/nilrag/config.py
@@ -16,6 +16,7 @@ def load_nil_db_config(
     require_schema_id: bool = False,
     require_diff_query_id: bool = False,
     require_clusters_schema_id: bool = False,
+    require_cluster_diff_query_id: bool = False,
 ) -> Tuple[NilDB, Optional[str]]:
     """
     Load nilDB configuration from JSON file.
@@ -68,6 +69,8 @@ def load_nil_db_config(
             raise ValueError("Error: diff_query_id not found in node data")
         if require_clusters_schema_id and "clusters_schema_id" not in node_data:
             raise ValueError("Error: clusters_schema_id not found in node data")
+        if require_cluster_diff_query_id and "cluster_diff_query_id" not in node_data:
+            raise ValueError("Error: cluster_diff_query_id not found in node data")
 
         # Create node with all available fields
         node = Node(
@@ -78,6 +81,7 @@ def load_nil_db_config(
             schema_id=node_data.get("schema_id"),
             diff_query_id=node_data.get("diff_query_id"),
             clusters_schema_id=node_data.get("clusters_schema_id"),
+            cluster_diff_query_id=node_data.get("cluster_diff_query_id"),
         )
         nodes.append(node)
 

--- a/src/nilrag/config.py
+++ b/src/nilrag/config.py
@@ -17,6 +17,8 @@ def load_nil_db_config(
     require_diff_query_id: bool = False,
     require_clusters_schema_id: bool = False,
     require_cluster_diff_query_id: bool = False,
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
 ) -> Tuple[NilDB, Optional[str]]:
     """
     Load nilDB configuration from JSON file.

--- a/src/nilrag/config.py
+++ b/src/nilrag/config.py
@@ -28,6 +28,8 @@ def load_nil_db_config(
         require_schema_id: Whether to require schema_id in node data
         require_diff_query_id: Whether to require diff_query_id in node data
         require_clusters_schema_id: Whether to require clusters_schema_id in node data
+        require_cluster_diff_query_id: Whether to require cluster_diff_query_id in node data
+
 
     Returns:
         tuple: (NilDB instance, secret_key if required)

--- a/src/nilrag/config.py
+++ b/src/nilrag/config.py
@@ -15,6 +15,7 @@ def load_nil_db_config(
     require_bearer_token: bool = False,
     require_schema_id: bool = False,
     require_diff_query_id: bool = False,
+    require_clusters_schema_id: bool = False,
 ) -> Tuple[NilDB, Optional[str]]:
     """
     Load nilDB configuration from JSON file.
@@ -25,6 +26,7 @@ def load_nil_db_config(
         require_bearer_token: Whether to require bearer_token in node data
         require_schema_id: Whether to require schema_id in node data
         require_diff_query_id: Whether to require diff_query_id in node data
+        require_clusters_schema_id: Whether to require clusters_schema_id in node data
 
     Returns:
         tuple: (NilDB instance, secret_key if required)
@@ -64,6 +66,8 @@ def load_nil_db_config(
             raise ValueError("Error: schema_id not found in node data")
         if require_diff_query_id and "diff_query_id" not in node_data:
             raise ValueError("Error: diff_query_id not found in node data")
+        if require_clusters_schema_id and "clusters_schema_id" not in node_data:
+            raise ValueError("Error: clusters_schema_id not found in node data")
 
         # Create node with all available fields
         node = Node(
@@ -73,6 +77,7 @@ def load_nil_db_config(
             bearer_token=node_data.get("bearer_token"),
             schema_id=node_data.get("schema_id"),
             diff_query_id=node_data.get("diff_query_id"),
+            clusters_schema_id=node_data.get("clusters_schema_id"),
         )
         nodes.append(node)
 

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -7,6 +7,7 @@ from typing import Union
 import nilql
 import numpy as np
 from sentence_transformers import SentenceTransformer
+from sklearn.cluster import KMeans
 
 
 # Load text from file
@@ -208,3 +209,25 @@ def decrypt_string_list(sk, lst: list) -> list:
         list: List of decrypted strings
     """
     return [nilql.decrypt(sk, l) for l in lst]
+
+def cluster_embeddings(embeddings: np.ndarray, num_clusters: int):
+    """
+    Cluster the given embeddings using K-Means.
+    
+    Args:
+        embeddings (list of list of float): The embeddings to cluster.
+        num_clusters (int): The number of clusters to form.
+    
+    Returns:
+        tuple: (labels, centroids)
+    """
+    print(f"Clustering data into {num_clusters} clusters...")
+
+    embeddings_array = np.array(embeddings)  # Convert to NumPy array
+    kmeans = KMeans(n_clusters=num_clusters, random_state=42, n_init=10)
+    labels = kmeans.fit_predict(embeddings_array)
+    centroids = kmeans.cluster_centers_
+    # Convert each centroid to fixed-point
+    centroids = [ [to_fixed_point(val) for val in centroid] for centroid in centroids ]
+    print("Clustering completed!")
+    return labels, centroids

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -103,31 +103,26 @@ def find_closest_chunks(
     sorted_indices = np.argsort(distances)
     return [(chunks[idx], distances[idx]) for idx in sorted_indices[:top_k]]
 
-def get_closest_centroid(prompt: str, centroids: list[int]) -> list[int]:
+def get_closest_centroid(query_embedding: np.ndarray, centroids: list[int]) -> list[int]:
     """
     Find the closest centroid for a given query embedding.
     
     Args:
-        query_embedding (list): The embedding vector of the query in floating-point format
+        query_embedding (np.ndarray): The embedding vector of the query in floating-point format
         centroids (list): List of centroid vectors in fixed-point format
         
     Returns:
         int: The index of the closest centroid
     """
-     # Generate embedding for the prompt
-    query_embedding = generate_embeddings_huggingface(prompt)
-
     # Convert query embedding to fixed-point for comparison
     query_embedding_fixed = [to_fixed_point(val) for val in query_embedding]
     
     # Find closest centroid
-    closest_centroid_idx = None
-    min_distance = float('inf')
-    for i, centroid in enumerate(centroids):
-        distance = euclidean_distance(query_embedding_fixed, centroid)
-        if distance < min_distance:
-            min_distance = distance
-            closest_centroid_idx = i
+    # closest_centroid_idx = None
+    closest_centroid_idx = min(  
+        range(len(centroids)),  
+        key=lambda i: euclidean_distance(query_embedding_fixed, centroids[i])  
+    )
             
     return centroids[closest_centroid_idx]
 

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -257,18 +257,10 @@ def cluster_embeddings(embeddings: np.ndarray, num_clusters: int):
     labels = kmeans.fit_predict(embeddings_array)
     centroids = kmeans.cluster_centers_
     
-    print(f"Clustering results:")
-    print(f"Number of labels: {len(labels)}")
-    print(f"Number of centroids: {len(centroids)}")
     print("Cluster sizes:")
     for i in range(num_clusters):
         print(f"Cluster {i}: {np.sum(labels == i)} documents")
-    
     # Convert each centroid to fixed-point
     centroids = [ [to_fixed_point(val) for val in centroid] for centroid in centroids ]
-    print("First few values of each centroid:")
-    for i, centroid in enumerate(centroids):
-        print(f"Centroid {i}: {centroid[:5]}...")
-    
     print("Clustering completed!")
     return labels, centroids

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -103,28 +103,32 @@ def find_closest_chunks(
     sorted_indices = np.argsort(distances)
     return [(chunks[idx], distances[idx]) for idx in sorted_indices[:top_k]]
 
-def get_closest_centroid(query_embedding: np.ndarray, centroids: list[int]) -> list[int]:
+
+def get_closest_centroid(
+    query_embedding: np.ndarray, centroids: list[int]
+) -> list[int]:
     """
     Find the closest centroid for a given query embedding.
-    
+
     Args:
         query_embedding (np.ndarray): The embedding vector of the query in floating-point format
         centroids (list): List of centroid vectors in fixed-point format
-        
+
     Returns:
         int: The index of the closest centroid
     """
     # Convert query embedding to fixed-point for comparison
     query_embedding_fixed = [to_fixed_point(val) for val in query_embedding]
-    
+
     # Find closest centroid
     # closest_centroid_idx = None
-    closest_centroid_idx = min(  
-        range(len(centroids)),  
-        key=lambda i: euclidean_distance(query_embedding_fixed, centroids[i])  
+    closest_centroid_idx = min(
+        range(len(centroids)),
+        key=lambda i: euclidean_distance(query_embedding_fixed, centroids[i]),
     )
-            
+
     return centroids[closest_centroid_idx]
+
 
 def group_shares_by_id(shares_per_party: list, transform_share_fn: callable):
     """
@@ -232,18 +236,19 @@ def decrypt_string_list(sk, lst: list) -> list:
     """
     return [nilql.decrypt(sk, l) for l in lst]
 
+
 def cluster_embeddings(embeddings: np.ndarray, num_clusters: int):
     """
     Cluster the given embeddings using K-Means.
-    
+
     Args:
         embeddings (list of list of float): The embeddings to cluster.
         num_clusters (int): The number of clusters to form.
-    
+
     Returns:
         tuple: (labels, centroids)
     """
-    print(f"Starting clustering process:")
+    print("Starting clustering process:")
     print(f"Number of embeddings: {len(embeddings)}")
     print(f"Requested number of clusters: {num_clusters}")
 
@@ -251,11 +256,11 @@ def cluster_embeddings(embeddings: np.ndarray, num_clusters: int):
     kmeans = KMeans(n_clusters=num_clusters, random_state=42, n_init=10)
     labels = kmeans.fit_predict(embeddings_array)
     centroids = kmeans.cluster_centers_
-    
+
     print("Cluster sizes:")
     for i in range(num_clusters):
         print(f"Cluster {i}: {np.sum(labels == i)} documents")
     # Convert each centroid to fixed-point
-    centroids = [ [to_fixed_point(val) for val in centroid] for centroid in centroids ]
+    centroids = [[to_fixed_point(val) for val in centroid] for centroid in centroids]
     print("Clustering completed!")
     return labels, centroids

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -104,7 +104,7 @@ def find_closest_chunks(
     return [(chunks[idx], distances[idx]) for idx in sorted_indices[:top_k]]
 
 
-def get_closest_centroid(
+def compute_closest_centroid(
     query_embedding: np.ndarray, centroids: list[int]
 ) -> list[int]:
     """

--- a/src/nilrag/util.py
+++ b/src/nilrag/util.py
@@ -103,7 +103,7 @@ def find_closest_chunks(
     sorted_indices = np.argsort(distances)
     return [(chunks[idx], distances[idx]) for idx in sorted_indices[:top_k]]
 
-def get_closest_centroid(prompt: str, centroids: list[int]) -> int:
+def get_closest_centroid(prompt: str, centroids: list[int]) -> list[int]:
     """
     Find the closest centroid for a given query embedding.
     
@@ -129,7 +129,7 @@ def get_closest_centroid(prompt: str, centroids: list[int]) -> int:
             min_distance = distance
             closest_centroid_idx = i
             
-    return closest_centroid_idx, centroids[closest_centroid_idx]
+    return centroids[closest_centroid_idx]
 
 def group_shares_by_id(shares_per_party: list, transform_share_fn: callable):
     """

--- a/test/rag.py
+++ b/test/rag.py
@@ -17,7 +17,7 @@ from src.nilrag.util import (create_chunks, decrypt_float_list,
                              generate_embeddings_huggingface, load_file)
 
 DEFAULT_CONFIG = "test/nildb_config.json"
-DEFAULT_PROMPT = "Who is Danielle Miller?"
+DEFAULT_PROMPT = "Who is Michelle Ross?"
 RUN_OPTIONAL_TESTS = False
 
 


### PR DESCRIPTION
Adding the feature of performing queries in a database that was clustered.

- added field in `schema` to store the centroid that is closer to each embedding
- created a `clusters' schema` to store all centroids
- created a `cluster query schema` to store query with a filter

Now one can upload cluster data and perform queries on clustered data.